### PR TITLE
Add default base url in google searcher class

### DIFF
--- a/app/Contracts/Searcher.php
+++ b/app/Contracts/Searcher.php
@@ -6,5 +6,5 @@ use Facebook\WebDriver\WebDriver;
 
 interface Searcher
 {
-    public function search(string $url, WebDriver $driver, array $keywords): void;
+    public function search(WebDriver $driver, array $keywords): void;
 }

--- a/app/Http/Controllers/SearcherController.php
+++ b/app/Http/Controllers/SearcherController.php
@@ -36,10 +36,9 @@ class SearcherController extends Controller
         }
         try {
             $keywords = $this->fileInputParser->parse($request->file('keywords'));
-            $url = 'https://www.google.com/search?hl=en&q=';
 
             foreach (array_chunk($keywords, 10) as $keywordsChunk) {
-                $this->searchChunk($url, $keywordsChunk);
+                $this->searchChunk($keywordsChunk);
             }
             return response()->json("Keywords uploaded successfully");
         } catch (\Exception $exception) {
@@ -48,12 +47,12 @@ class SearcherController extends Controller
 
     }
 
-    private function searchChunk($url, $keywordsChunk)
+    private function searchChunk($keywordsChunk)
     {
         $driver = null;
         try {
             $driver = $this->browser->getDriver();
-            $this->searcher->search($url, $driver, $keywordsChunk);
+            $this->searcher->search($driver, $keywordsChunk);
         } catch (\Exception $exception) {
             Log::error("Exception happened while searching these keywords " . json_encode($keywordsChunk) . $exception->getMessage());
             if($exception instanceof PhpWebDriverExceptionInterface){

--- a/app/Searchers/GoogleSearcher.php
+++ b/app/Searchers/GoogleSearcher.php
@@ -14,18 +14,26 @@ use Illuminate\Support\Facades\Log;
 class GoogleSearcher implements Searcher
 {
     protected WebDriver $driver;
-    protected $host = 'www.google.com';
+    protected string $host = 'www.google.com';
+
+    /**
+     * @param string $url
+     */
+    public function __construct(protected string $url = 'https://www.google.com/search?hl=en&q=')
+    {
+    }
+
 
     /**
      * @param WebDriver $driver
      * @param array $keywords
      * @return void
      */
-    public function search(string $url, WebDriver $driver, array $keywords): void
+    public function search(WebDriver $driver, array $keywords): void
     {
         $this->driver = $driver;
         foreach ($keywords as $keyword) {
-            $this->performSearch($url, $keyword);
+            $this->performSearch($keyword);
 
             SearchStatGenerated::dispatch(
                 $keyword,
@@ -38,9 +46,9 @@ class GoogleSearcher implements Searcher
         }
     }
 
-    private function performSearch(string $url, string $keyword): void
+    private function performSearch(string $keyword): void
     {
-        $this->driver->get($url . urlencode($keyword));
+        $this->driver->get($this->url . urlencode($keyword));
 
         $this->driver->wait(5)->until(
             WebDriverExpectedCondition::visibilityOfElementLocated(WebDriverBy::id('result-stats'))

--- a/tests/Feature/GoogleSearcherTest.php
+++ b/tests/Feature/GoogleSearcherTest.php
@@ -46,8 +46,8 @@ class GoogleSearcherTest extends TestCase
 
         $url = 'http://host.docker.internal:8800/';
 
-        $search = new GoogleSearcher();
-        $search->search($url, $driver, $keywords);
+        $search = new GoogleSearcher($url);
+        $search->search($driver, $keywords);
 
         foreach ($keywords as $keyword) {
             Event::assertDispatched(SearchStatGenerated::class, function ($event) use ($keyword) {
@@ -66,8 +66,8 @@ class GoogleSearcherTest extends TestCase
 
         $keywords = ['cheap flights'];
         $url = 'http://host.docker.internal:8800/';
-        $searcher = new GoogleSearcher();
-        $searcher->search($url, $driver, $keywords);
+        $searcher = new GoogleSearcher($url);
+        $searcher->search($driver, $keywords);
 
         foreach ($keywords as $keyword) {
             Event::assertDispatched(SearchStatGenerated::class, function ($event) use ($keyword) {


### PR DESCRIPTION
Resolve #34


Added google base url in the constructor. This way [GoogleSearcher](https://github.com/mosharaf13/fleet-searcher/blob/main/app/Searchers/GoogleSearcher.php) can work without providing a url and [GoogleSearcherTest](https://github.com/mosharaf13/fleet-searcher/blob/main/tests/Feature/GoogleSearcherTest.php) class can send custom url to test it with local html file.